### PR TITLE
Add gammas and log-likelihood per trial to the fitGlmHmm.m output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+.DS_Store
+*.mat
+*.asv

--- a/fitGlmHmm.m
+++ b/fitGlmHmm.m
@@ -1,5 +1,5 @@
-function [model,ll,iter] = fitGlmHmm(y,x,w0,A0,varargin)
-%[model, ll, iter] = fitGlmHmm(y, x, w0, A0, varargin)
+function [model,ll,iter,gammas,ll_mean] = fitGlmHmm(y,x,w0,A0,varargin)
+% [model, ll, iter, gammas, ll_mean] = fitGlmHmm(y, x, w0, A0, varargin)
 % Fits a GLM-HMM to data for a logistic sigmoid emissions models. Number of
 % latent states is implicitly taken from the second dimension of w0.
 %
@@ -36,6 +36,8 @@ function [model,ll,iter] = fitGlmHmm(y,x,w0,A0,varargin)
 %   ll              - (1 x NIter) log-likelihood of the model fit
 %   iter            - number of iterations it took for the model to
 %                     converge
+%   gammas          - (Nstates x NTrials) Marginal posterior distribution
+%   ll_mean         - mean log-likelihood of the fit per trial/time point
 %
 % Example call:
 % [model,ll,iter] = fitGlmHmm(y,x,w0,A0,'new_sess',new_sess,'maxiter',2000)
@@ -131,6 +133,7 @@ while i<p.maxiter && (dLL>p.tol || dLL<0)
 end
 [~, ~, ll(i+1)] = runBaumWelch(y,x,model,p.new_sess);
 ll(isnan(ll)) = []; % get rid of nan values
+ll_mean = ll / T;
 iter = i;
 fprintf(' done\n');
 

--- a/fitGlmHmm.m
+++ b/fitGlmHmm.m
@@ -37,10 +37,10 @@ function [model,ll,iter,gammas,ll_mean] = fitGlmHmm(y,x,w0,A0,varargin)
 %   iter            - number of iterations it took for the model to
 %                     converge
 %   gammas          - (Nstates x NTrials) Marginal posterior distribution
-%   ll_mean         - mean log-likelihood of the fit per trial/time point
+%   ll_mean         - mean (per trial/time point) log-likelihood of the final fit
 %
 % Example call:
-% [model,ll,iter] = fitGlmHmm(y,x,w0,A0,'new_sess',new_sess,'maxiter',2000)
+% [model,ll,iter,gammas,ll_mean] = fitGlmHmm(y,x,w0,A0,'new_sess',new_sess,'maxiter',2000)
 
 %% %%%%%%%%%%%%%%%%%%%%%% Input parameters %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ip = inputParser;
@@ -133,7 +133,7 @@ while i<p.maxiter && (dLL>p.tol || dLL<0)
 end
 [~, ~, ll(i+1)] = runBaumWelch(y,x,model,p.new_sess);
 ll(isnan(ll)) = []; % get rid of nan values
-ll_mean = ll / T;
+ll_mean = ll(end) / nt;
 iter = i;
 fprintf(' done\n');
 


### PR DESCRIPTION
Hi I find it super useful to be able to access these two variables from the main fit function:
- `gammas` (marginal posterior probability) so that the posterior probability at each trial at each state can be directly inspected from the fit.
- `ll_mean` as log-likelihood per trial/time point. It can be used to measure the goodness of the fit across datasets with different number of entries. Right now it's calculated simply as `ll / num_trials`. Maybe there are more sophisticated ways to quantify the goodness of the fit which is independent of the size of the dataset.